### PR TITLE
[FIX] Translation string escape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Section Order:
 
 ### Fixed
 
+- Escaping translation strings to fix potential issues with French and Italian translations
 - Search field positioning in the DataTables
 - Sticky behaviour in fleet composition details tables
 

--- a/aa_intel_tool/locale/django.pot
+++ b/aa_intel_tool/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: AA Intel Tool 2.5.2\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-intel-tool/issues\n"
-"POT-Creation-Date: 2024-12-16 14:22+0100\n"
+"POT-Creation-Date: 2025-01-13 15:13+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -196,97 +196,92 @@ msgstr ""
 msgid "The fleet composition module is currently disabled."
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:28
+#: aa_intel_tool/templates/aa_intel_tool/base.html:20
 msgid "Permalink successfully copied"
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:29
+#: aa_intel_tool/templates/aa_intel_tool/base.html:21
 msgid ""
 "Something went wrong. Nothing copied. Maybe your browser does not support "
 "this function."
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:34
+#: aa_intel_tool/templates/aa_intel_tool/base.html:22
 #: aa_intel_tool/templates/aa_intel_tool/partials/scan/chatlist/alliances.html:4
 #: aa_intel_tool/templates/aa_intel_tool/partials/scan/chatlist/corporations.html:4
 #: aa_intel_tool/templates/aa_intel_tool/partials/scan/chatlist/pilots.html:3
 msgid "Unaffiliated / No Alliance"
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:35
+#: aa_intel_tool/templates/aa_intel_tool/base.html:23
 msgid "NPC Corp"
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:38
+#: aa_intel_tool/templates/aa_intel_tool/base.html:24
 msgctxt "Decimal separator"
 msgid "."
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:39
+#: aa_intel_tool/templates/aa_intel_tool/base.html:25
 msgctxt "Thousands separator"
 msgid ","
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:40
+#: aa_intel_tool/templates/aa_intel_tool/base.html:26
 msgid "No data available in this table"
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:41
+#: aa_intel_tool/templates/aa_intel_tool/base.html:27
 msgctxt "Keep _END_ as it is. It will be replaced by a number."
 msgid "Showing _END_ entries"
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:42
+#: aa_intel_tool/templates/aa_intel_tool/base.html:28
 msgctxt "Keep _MAX_ as it is. It will be replaced by a number."
 msgid "(filtered from _MAX_ total entries)"
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:43
+#: aa_intel_tool/templates/aa_intel_tool/base.html:29
 msgid "No records available"
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:45
-msgctxt "Keep _MENU_ as it is. It will be replaced by an HTML construct."
-msgid "Show _MENU_"
-msgstr ""
-
-#: aa_intel_tool/templates/aa_intel_tool/base.html:46
+#: aa_intel_tool/templates/aa_intel_tool/base.html:30
 msgid "Loading …"
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:47
+#: aa_intel_tool/templates/aa_intel_tool/base.html:31
 msgid "Processing …"
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:48
+#: aa_intel_tool/templates/aa_intel_tool/base.html:32
 msgid "Nothing found, sorry …"
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:50
+#: aa_intel_tool/templates/aa_intel_tool/base.html:33
 msgid "Search …"
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:52
+#: aa_intel_tool/templates/aa_intel_tool/base.html:34
 msgid "First"
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:53
+#: aa_intel_tool/templates/aa_intel_tool/base.html:35
 msgid "Last"
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:54
+#: aa_intel_tool/templates/aa_intel_tool/base.html:36
 msgid "Next"
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:55
+#: aa_intel_tool/templates/aa_intel_tool/base.html:37
 msgid "Previous"
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:58
+#: aa_intel_tool/templates/aa_intel_tool/base.html:38
 msgid ": activate to sort column ascending"
 msgstr ""
 
-#: aa_intel_tool/templates/aa_intel_tool/base.html:59
+#: aa_intel_tool/templates/aa_intel_tool/base.html:39
 msgid ": activate to sort column descending"
 msgstr ""
 

--- a/aa_intel_tool/templates/aa_intel_tool/base.html
+++ b/aa_intel_tool/templates/aa_intel_tool/base.html
@@ -17,6 +17,27 @@
         </div>
 
         <div class="aa-intel-tool-body">
+            {% translate "Permalink successfully copied" as copyToClipboardSuccess %}
+            {% translate "Something went wrong. Nothing copied. Maybe your browser does not support this function." as copyToClipboardError %}
+            {% translate "Unaffiliated / No Alliance" as scanDataEmpty %}
+            {% translate "NPC Corp" as scanDataNpcCorp %}
+            {% translate "." context "Decimal separator" as decimalSeparator %}
+            {% translate "," context "Thousands separator" as thousandsSeparator %}
+            {% translate "No data available in this table" as emptyTable %}
+            {% translate "Showing _END_ entries" as info context "Keep _END_ as it is. It will be replaced by a number." %}
+            {% translate "(filtered from _MAX_ total entries)" as infoFiltered context "Keep _MAX_ as it is. It will be replaced by a number." %}
+            {% translate "No records available" as infoEmpty %}
+            {% translate "Loading …" as loadingRecords %}
+            {% translate "Processing …" as processing %}
+            {% translate "Nothing found, sorry …" as zeroRecords%}
+            {% translate "Search …" as searchPlaceholder %}
+            {% translate "First" as paginateFirst %}
+            {% translate "Last" as paginateLast %}
+            {% translate "Next" as paginateNext %}
+            {% translate "Previous" as paginatePrevious %}
+            {% translate ": activate to sort column ascending" as ariaSortAscending %}
+            {% translate ": activate to sort column descending" as ariaSortDescending %}
+
             <script>
                 const aaIntelToolJsSettingsDefaults = {
                     language: '{{ LANGUAGE_CODE }}',
@@ -25,38 +46,38 @@
                         copyToClipboard: {
                             permalink: {
                                 text: {
-                                    success: '{% translate "Permalink successfully copied" %}',
-                                    error: '{% translate "Something went wrong. Nothing copied. Maybe your browser does not support this function." %}'
+                                    success: '{{ copyToClipboardSuccess|escapejs }}',
+                                    error: '{{ copyToClipboardError|escapejs }}'
                                 }
                             }
                         },
                         scanData: {
-                            empty: '{% translate "Unaffiliated / No Alliance" %}',
-                            npcCorp: '{% translate "NPC Corp" %}',
+                            empty: '{{ scanDataEmpty|escapejs }}',
+                            npcCorp: '{{ scanDataNpcCorp|escapejs }}',
                         },
                         dataTables: {
-                            decimal: '{% translate "." context "Decimal separator" %}',
-                            thousands: '{% translate "," context "Thousands separator" %}',
-                            emptyTable: '{% translate "No data available in this table" %}',
-                            info: '{% translate "Showing _END_ entries" context "Keep _END_ as it is. It will be replaced by a number." %}',
-                            infoFiltered: '{% translate "(filtered from _MAX_ total entries)" context "Keep _MAX_ as it is. It will be replaced by a number." %}',
-                            infoEmpty: '{% translate "No records available" %}',
+                            decimal: '{{ decimalSeparator|escapejs }}',
+                            thousands: '{{ thousandsSeparator|escapejs }}',
+                            emptyTable: '{{ emptyTable|escapejs }}',
+                            info: '{{ info|escapejs }}',
+                            infoFiltered: '{{ infoFiltered|escapejs }}',
+                            infoEmpty: '{{ infoEmpty|escapejs }}',
                             infoPostFix: '',
-                            lengthMenu: '{% translate "Show _MENU_" context "Keep _MENU_ as it is. It will be replaced by an HTML construct." %}',
-                            loadingRecords: '{% translate "Loading …" %}',
-                            processing: '{% translate "Processing …" %}',
-                            zeroRecords: '{% translate "Nothing found, sorry …" %}',
+                            lengthMenu: '_MENU_',
+                            loadingRecords: '{{ loadingRecords|escapejs }}',
+                            processing: '{{ processing|escapejs }}',
+                            zeroRecords: '{{ zeroRecords|escapejs }}',
                             search: '_INPUT_',
-                            searchPlaceholder: '{% translate "Search …" %}',
+                            searchPlaceholder: '{{ searchPlaceholder|escapejs }}',
                             paginate: {
-                                first: '{% translate "First" %}',
-                                last: '{% translate "Last" %}',
-                                next: '{% translate "Next" %}',
-                                previous: '{% translate "Previous" %}'
+                                first: '{{ paginateFirst|escapejs }}',
+                                last: '{{ paginateLast|escapejs }}',
+                                next: '{{ paginateNext|escapejs }}',
+                                previous: '{{ paginatePrevious|escapejs }}'
                             },
                             aria: {
-                                sortAscending: '{% translate ": activate to sort column ascending" %}',
-                                sortDescending: '{% translate ": activate to sort column descending" %}',
+                                sortAscending: '{{ ariaSortAscending|escapejs }}',
+                                sortDescending: '{{ ariaSortDescending|escapejs }}'
                             }
                         }
                     }


### PR DESCRIPTION
## Description

### Fixed

- Escaping translation strings to fix potential issues with French and Italian translations

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
