### PR TITLE
[RELEASE] v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ Section Order:
 ### Security
 -->
 
+## [2.7.0] - 2025-06-03
+
+### Changed
+
+- Translations updated
+
 ### Removed
 
 - Redundant header from public page

--- a/aa_intel_tool/__init__.py
+++ b/aa_intel_tool/__init__.py
@@ -5,5 +5,5 @@ App init
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.6.3"
+__version__ = "2.7.0"
 __title__ = _("Intel Parser")

--- a/aa_intel_tool/locale/django.pot
+++ b/aa_intel_tool/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Intel Tool 2.6.3\n"
+"Project-Id-Version: AA Intel Tool 2.7.0\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-intel-tool/issues\n"
-"POT-Creation-Date: 2025-05-05 22:48+0200\n"
+"POT-Creation-Date: 2025-06-03 12:14+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -21,7 +21,6 @@ msgstr ""
 #: aa_intel_tool/__init__.py:9
 #: aa_intel_tool/templates/aa_intel_tool/base.html:7
 #: aa_intel_tool/templates/aa_intel_tool/base.html:11
-#: aa_intel_tool/templates/aa_intel_tool/views/index.html:8
 #: aa_intel_tool/templates/aa_intel_tool/views/scan/chatlist.html:5
 #: aa_intel_tool/templates/aa_intel_tool/views/scan/dscan.html:5
 #: aa_intel_tool/templates/aa_intel_tool/views/scan/fleetcomp.html:5


### PR DESCRIPTION
## [2.7.0] - 2025-06-03

### Changed

- Translations updated

### Removed

- Redundant header from public page
- Cache breaker for static files. Doesn't work as expected with `django-sri`.