### PR TITLE
[RELEASE] v2.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ Section Order:
 ### Security
 -->
 
+## [2.7.1] - 2025-07-08
+
 ### Added
 
 - Default/Fallback exception message for `ParserError`
@@ -42,6 +44,7 @@ Section Order:
 ### Changed
 
 - Cast some translated strings to `str` to avoid potential issues
+- Translations updated
 
 ### Removed
 

--- a/aa_intel_tool/__init__.py
+++ b/aa_intel_tool/__init__.py
@@ -5,5 +5,5 @@ App init
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.7.0"
+__version__ = "2.7.1"
 __title__ = _("Intel Parser")

--- a/aa_intel_tool/locale/django.pot
+++ b/aa_intel_tool/locale/django.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: AA Intel Tool 2.7.0\n"
+"Project-Id-Version: AA Intel Tool 2.7.1\n"
 "Report-Msgid-Bugs-To: https://github.com/ppfeufer/aa-intel-tool/issues\n"
-"POT-Creation-Date: 2025-06-27 10:02+0200\n"
+"POT-Creation-Date: 2025-07-08 12:13+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -45,16 +45,16 @@ msgstr ""
 msgid "Intel Parser v{__version__}"
 msgstr ""
 
-#: aa_intel_tool/constants.py:61 aa_intel_tool/models.py:24
+#: aa_intel_tool/constants.py:56 aa_intel_tool/models.py:24
 msgid "Chat list"
 msgstr ""
 
-#: aa_intel_tool/constants.py:67 aa_intel_tool/models.py:22
+#: aa_intel_tool/constants.py:62 aa_intel_tool/models.py:22
 #: aa_intel_tool/templates/aa_intel_tool/partials/index/form.html:28
 msgid "D-Scan"
 msgstr ""
 
-#: aa_intel_tool/constants.py:73 aa_intel_tool/models.py:23
+#: aa_intel_tool/constants.py:68 aa_intel_tool/models.py:23
 #: aa_intel_tool/models.py:123
 #: aa_intel_tool/templates/aa_intel_tool/partials/index/form.html:33
 msgid "Fleet composition"


### PR DESCRIPTION
## [2.7.1] - 2025-07-08

### Added

- Default/Fallback exception message for `ParserError`

### Changed

- Cast some translated strings to `str` to avoid potential issues
- Translations updated

### Removed

- Unused constants