### PR TITLE
[RELEASE] v2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [2.9.0] - 2025-09-21
+
 ### Fixed
 
 - (JS Error) Uncaught TypeError: Cannot read properties of undefined (reading 'data')
@@ -605,5 +607,7 @@ Hopefully the last one before official release …
 [2.7.2]: https://github.com/ppfeufer/aa-intel-tool/compare/v2.7.1...v2.7.2 "v2.7.2"
 [2.8.0]: https://github.com/ppfeufer/aa-intel-tool/compare/v2.7.2...v2.8.0 "v2.8.0"
 [2.8.1]: https://github.com/ppfeufer/aa-intel-tool/compare/v2.8.0...v2.8.1 "v2.8.1"
+[2.9.0]: https://github.com/ppfeufer/aa-intel-tool/compare/v2.8.1...v2.9.0 "v2.9.0"
+[in development]: https://github.com/ppfeufer/aa-intel-tool/compare/v2.9.0...HEAD "In Development"
 [keep a changelog]: http://keepachangelog.com/ "Keep a Changelog"
 [semantic versioning]: http://semver.org/ "Semantic Versioning"

--- a/aa_intel_tool/__init__.py
+++ b/aa_intel_tool/__init__.py
@@ -5,5 +5,5 @@ App init
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "2.8.1"
+__version__ = "2.9.0"
 __title__ = _("Intel Parser")


### PR DESCRIPTION
## [2.9.0] - 2025-09-21

### Fixed

- (JS Error) Uncaught TypeError: Cannot read properties of undefined (reading 'data')

### Changed

- Switch to JS number formatter provided by the Alliance Auth framework
- Minimum requirements
  - Alliance Auth >= 4.10.0