### PR TITLE
[RELEASE] v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ Section Order:
 
 <!-- Your changes go here -->
 
+## [4.0.0] - 2026-06-07
+
 > [!IMPORTANT]
 >
 > **This version needs Alliance Auth v5!**
@@ -819,6 +821,7 @@ Hopefully the last one before official release…
 [3.0.1]: https://github.com/ppfeufer/aa-intel-tool/compare/v3.0.0...v3.0.1 "v3.0.1"
 [3.0.2]: https://github.com/ppfeufer/aa-intel-tool/compare/v3.0.1...v3.0.2 "v3.0.2"
 [3.1.0]: https://github.com/ppfeufer/aa-intel-tool/compare/v3.0.2...v3.1.0 "v3.1.0"
-[in development]: https://github.com/ppfeufer/aa-intel-tool/compare/v3.1.0...HEAD "In Development"
+[4.0.0]: https://github.com/ppfeufer/aa-intel-tool/compare/v3.1.0...v4.0.0 "v4.0.0"
+[in development]: https://github.com/ppfeufer/aa-intel-tool/compare/v4.0.0...HEAD "In Development"
 [keep a changelog]: http://keepachangelog.com/ "Keep a Changelog"
 [semantic versioning]: http://semver.org/ "Semantic Versioning"

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Make sure you're in the virtual environment (venv) of your Alliance Auth
 installation Then install the latest release directly from PyPi.
 
 ```shell
-pip install aa-intel-tool==3.1.0
+pip install aa-intel-tool==4.0.0
 ```
 
 ### Step 2: Configure Alliance Auth<a name="step-2-configure-alliance-auth"></a>

--- a/aa_intel_tool/__init__.py
+++ b/aa_intel_tool/__init__.py
@@ -5,7 +5,7 @@ App init
 # Django
 from django.utils.translation import gettext_lazy as _
 
-__version__ = "3.1.0"
+__version__ = "4.0.0"
 __title__ = "Intel Parser"
 __title_translated__ = _("Intel Parser")
 __verbose_name__ = "Intel Parser for Alliance Auth"


### PR DESCRIPTION
## [4.0.0] - 2026-06-07

> [!IMPORTANT]
> 
> **This version needs Alliance Auth v5!**
> 
> Please make sure to update your Alliance Auth instance **before** you install this
> version, otherwise an update to Alliance Auth will be pulled in unsupervised.

### Changed

- Some minor responsiveness improvements to the result tables

### Removed

- Support for Alliance Auth v4
