### PR TITLE
[CHANGE] Use `pk` instead of `id` when referring to the primary key

### DIFF
--- a/.github/workflows/automated-checks.yml
+++ b/.github/workflows/automated-checks.yml
@@ -3,7 +3,7 @@ name: Tests
 env:
   COVERAGE_DATABASE_VERSION: mariadb:10.11
   COVERAGE_PYTHON_VERSION: 3.12
-  NODE_VERSION: 24 # [LTS] End of Life: 30 Apr 2028 (https://endoflife.date/nodejs)
+  NODE_VERSION: 26 # [LTS] End of Life: 30 Apr 2029 (https://endoflife.date/nodejs)
   REDIS_VERSION: latest
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,4 +58,5 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           # The name of the file(s) to upload
           files: |
-            dist/*
+            dist/*.tar.gz
+            dist/*.whl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@
 # Set the default language versions for the hooks
 default_language_version:
   python: python3  # Force all Python hooks to use Python 3
-  node: 24.14.0  # Force all Node hooks to use this specific Node version
+  node: 26.3.0  # Force all Node hooks to use this specific Node version
 
 # https://pre-commit.ci/
 ci:
@@ -68,7 +68,7 @@ repos:
         name: Check for large files
         description: Check for large files that were added to the repository.
         args:
-          - --maxkb=1000
+          - --maxkb=2048  # 2 MB
 
       - id: detect-private-key
         name: Detect private key
@@ -120,8 +120,10 @@ repos:
         name: End of file fixer
         description: Ensure that files end with a newline.
 
-  - repo: https://github.com/eslint/eslint
-    rev: 9089853a593d6c7c0f11367da08a829e0ddfe092  # frozen: v10.6.0
+#  - repo: https://github.com/eslint/eslint
+#    rev: 9089853a593d6c7c0f11367da08a829e0ddfe092  # frozen: v10.6.0
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: 8763fc929b6232999d541a3d8eb49965a6b71afb  # frozen: v10.6.0
     hooks:
       - id: eslint
         name: ESLint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ Section Order:
 
 ### Changed
 
+- Use `pk` instead of `id` when referring to the primary key of a model instance, since `id` is not guaranteed to be the primary key in Django.
 - Migrated to Alliance Auth proxy models for `Permission`, `User` and `Group`
 
 ## [4.1.1] - 2026-07-06

--- a/aa_intel_tool/parser/module/dscan.py
+++ b/aa_intel_tool/parser/module/dscan.py
@@ -358,7 +358,7 @@ def parse(scan_data: list) -> Scan:
     ansiblex_destination, counter, eve_ids = _get_scan_details(scan_data=scan_data)
 
     eve_types = ItemType.objects.filter(id__in=set(eve_ids["all"])).values_list(
-        "id", "name", "group__id", "group__name", "mass", named=True
+        "pk", "name", "group__pk", "group__name", "mass", named=True
     )
 
     logger.debug(f"EVE Types for D-Scan: {list(eve_types)}")

--- a/aa_intel_tool/parser/module/fleetcomp.py
+++ b/aa_intel_tool/parser/module/fleetcomp.py
@@ -42,7 +42,7 @@ def get_fleet_composition(pilots: dict, ships: dict) -> dict:
 
     # Get ship class details from DB
     ship_class_details = ItemType.objects.filter(name__in=ships["class"]).values_list(
-        "id", "name", "group__id", "group__name", "mass", named=True
+        "pk", "name", "group__pk", "group__name", "mass", named=True
     )
 
     # Build ship class and type dictionaries
@@ -50,11 +50,11 @@ def get_fleet_composition(pilots: dict, ships: dict) -> dict:
         # Build ship class dict
         ships["class"][ship_class.name].update(
             {
-                "id": ship_class.id,
+                "id": ship_class.pk,
                 "name": ship_class.name,
-                "type_id": ship_class.group__id,
+                "type_id": ship_class.group__pk,
                 "type_name": ship_class.group__name,
-                "image": eveimageserver.type_icon_url(type_id=ship_class.id, size=32),
+                "image": eveimageserver.type_icon_url(type_id=ship_class.pk, size=32),
                 "mass": ship_class.mass * ships["class"][ship_class.name]["count"],
             }
         )
@@ -62,7 +62,7 @@ def get_fleet_composition(pilots: dict, ships: dict) -> dict:
         # Build ship type dict
         ships["type"][ship_class.group__name].update(
             {
-                "id": ship_class.group__id,
+                "id": ship_class.group__pk,
                 "name": ship_class.group__name,
             }
         )
@@ -84,8 +84,8 @@ def get_fleet_composition(pilots: dict, ships: dict) -> dict:
                 "portrait": pilot.portrait_url_32,
                 "evewho": evewho.character_url(pilot.character_id),
                 "zkillboard": zkillboard.character_url(pilot.character_id),
-                "ship_id": pilot_ship_class.id,
-                "ship_type_id": pilot_ship_class.group__id,
+                "ship_id": pilot_ship_class.pk,
+                "ship_type_id": pilot_ship_class.group__pk,
             }
         )
 

--- a/aa_intel_tool/tests/test_parser_module_feetcomp.py
+++ b/aa_intel_tool/tests/test_parser_module_feetcomp.py
@@ -42,16 +42,16 @@ class TestGetFleetComposition(BaseTestCase):
         }
         ship_class_details = [
             SimpleNamespace(
-                id=1,
+                pk=1,
                 name="Ship Class 1",
-                group__id=10,
+                group__pk=10,
                 group__name="Group 1",
                 mass=1000,
             ),
             SimpleNamespace(
-                id=2,
+                pk=2,
                 name="Ship Class 2",
-                group__id=20,
+                group__pk=20,
                 group__name="Group 2",
                 mass=2000,
             ),


### PR DESCRIPTION
## Description

### Changed

- Use `pk` instead of `id` when referring to the primary key of a model instance, since `id` is not guaranteed to be the primary key in Django.


## Type of Change:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have checked my code and corrected any misspellings
